### PR TITLE
Allow url with = in path

### DIFF
--- a/aldryn_redirects/middleware.py
+++ b/aldryn_redirects/middleware.py
@@ -2,13 +2,13 @@ from django import http
 from django.conf import settings
 
 from .models import Redirect
-
+from urllib2 import unquote
 
 class RedirectFallbackMiddleware(object):
     def process_response(self, request, response):
         if response.status_code != 404:
             return response  # No need to check for a redirect for non-404 responses.
-        path = request.get_full_path()
+        path = unquote(request.get_full_path()) # To handle url path containing chars like =, /path=path/
         try:
             r = Redirect.objects.get(site__id__exact=settings.SITE_ID, old_path=path)
         except Redirect.DoesNotExist:


### PR DESCRIPTION
When the url contains = in the path, the redirect does not work.
For eg: setting old path as: /test/a=b/ and new path as /test/ gives 404.