### PR TITLE
Process request instead of response

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+1.1.0 (2017-03-21)
+------------------
+
+* Switch from `process_response` to `process_request` in middleware:
+  Changes from a "fallback" middleware that only acted on 404s to an
+  eager middleware, trying to redirect all requests (including such
+  to / without language prefix)
+
+
 1.0.0 (2016-02-23)
 ------------------
 

--- a/aldryn_redirects/admin.py
+++ b/aldryn_redirects/admin.py
@@ -1,9 +1,7 @@
 from django.contrib import admin
-from django import forms
 from parler.admin import TranslatableAdmin
 from aldryn_translation_tools.admin import AllTranslationsMixin
 
-from django.contrib.sites.models import Site
 from .models import Redirect
 
 

--- a/aldryn_redirects/middleware.py
+++ b/aldryn_redirects/middleware.py
@@ -5,9 +5,7 @@ from .models import Redirect
 
 
 class RedirectFallbackMiddleware(object):
-    def process_response(self, request, response):
-        if response.status_code != 404:
-            return response  # No need to check for a redirect for non-404 responses.
+    def process_request(self, request):
         path = request.get_full_path()
         try:
             r = Redirect.objects.get(site__id__exact=settings.SITE_ID, old_path=path)
@@ -26,6 +24,3 @@ class RedirectFallbackMiddleware(object):
             if r.new_path == '':
                 return http.HttpResponseGone()
             return http.HttpResponsePermanentRedirect(r.new_path)
-
-        # No redirect was found. Return the response.
-        return response

--- a/aldryn_redirects/models.py
+++ b/aldryn_redirects/models.py
@@ -16,7 +16,7 @@ class Redirect(TranslatableModel):
         ),
     )
     translations = TranslatedFields(
-        new_path = models.CharField(
+        new_path=models.CharField(
             _('redirect to'), max_length=200, blank=True,
             help_text=_(
                 "This can be either an absolute path (as above) or a full URL "
@@ -30,12 +30,11 @@ class Redirect(TranslatableModel):
         verbose_name_plural = _('redirects')
         unique_together = (('site', 'old_path'),)
         ordering = ('old_path',)
-    
+
     def __unicode__(self):
         new_paths = ', '.join([
             '{}:{}'.format(t.language_code, t.new_path)
-            for t
-            in self.translations.all()
+            for t in self.translations.all()
         ])
         if not new_paths:
             new_paths = ugettext('None')


### PR DESCRIPTION
We don't want to act like a fallback middleware. If there's a root redirect, e.g. /tos, this would never be able to redirect (if the LocaleMiddleware was installed), since that one would redirect to /en/tos immediately