### PR TITLE
Fix default-select when only 1 site

### DIFF
--- a/aldryn_redirects/admin.py
+++ b/aldryn_redirects/admin.py
@@ -73,7 +73,7 @@ class RedirectAdmin(DeletionMixin, AllTranslationsMixin, TranslatableAdmin):
 
         # if there is only one site, select it by default
         if site_field.queryset.all().count() == 1:
-            site_field.initial = [site_field.queryset.get(), ]
+            site_field.initial = site_field.queryset.get()
         return form
 
     def export_view(self, request):


### PR DESCRIPTION
On multilanguage redirects the selector is a simple single-select, thus the single option need not be an array (being an array breaks the default-select behavior).
