### PR TITLE
Make the middleware pre and post Django 1.10 compatible

### DIFF
--- a/aldryn_redirects/middleware.py
+++ b/aldryn_redirects/middleware.py
@@ -4,11 +4,12 @@ from django import http
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db.models import Q
+from django.utils.deprecation import MiddlewareMixin
 
 from .models import Redirect, StaticRedirect
 
 
-class RedirectFallbackMiddleware(object):
+class RedirectFallbackMiddleware(MiddlewareMixin):
     def process_request(self, request):
         static_redirect = StaticRedirect.objects.get_for_request(request)
         if static_redirect:

--- a/aldryn_redirects/middleware.py
+++ b/aldryn_redirects/middleware.py
@@ -4,7 +4,11 @@ from django import http
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.db.models import Q
-from django.utils.deprecation import MiddlewareMixin
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Django<1.10
+    MiddlewareMixin = object
 
 from .models import Redirect, StaticRedirect
 


### PR DESCRIPTION
These changes and future changes are part of a larger task to improve this application for Django CMS 4.0. They should be added to a new support/4.0 branch rather than master unless agreed otherwise.